### PR TITLE
Include PlugCors to Endpoint

### DIFF
--- a/source/blog/2015-06-04-build-a-blog-with-phoenix-and-ember.html.markdown
+++ b/source/blog/2015-06-04-build-a-blog-with-phoenix-and-ember.html.markdown
@@ -491,6 +491,13 @@ Fetched package
 Unpacked package tarball (/Users/max/.hex/packages/plug_cors-0.7.3.tar)
 ~~~
 
+First edit `lib/rest_api/endpoint.ex` to include PlugCors:
+
+~~~elixir
+ plug PlugCors
+ plug RestApi.Router
+~~~
+
 Now edit `web/router.ex` to change:
 
 ~~~elixir


### PR DESCRIPTION
Noticed while setting up Ember with Phoenix that it was continuing to have access problems reading from localhost:4000. Some digging around revealed that you need to make sure the PlugCors plug is included in the app's endpoint, so this adds that.

Also: Thank you for writing this blog post! I just recently got into Phoenix and hadn't considered using Ember as a front-end, so this was super helpful in prodding me in that direction.